### PR TITLE
moves add new timer link under the timer collapse list hierarchy

### DIFF
--- a/src/components/WrapperSidebar.vue
+++ b/src/components/WrapperSidebar.vue
@@ -11,20 +11,10 @@
       </v-list-tile-title>
     </v-list-tile>
     <timer-list />
-    <v-list-tile to='/timer'>
-      <v-list-tile-action>
-        <v-icon>
-          alarm_add
-        </v-icon>
-      </v-list-tile-action>
-      <v-list-tile-title>
-        Add a New Timer
-      </v-list-tile-title>
-    </v-list-tile>
     <v-list-tile to='/statistics'>
       <v-list-tile-action>
         <v-icon>
-          history
+          timeline
         </v-icon>
       </v-list-tile-action>
       <v-list-tile-title>

--- a/src/components/WrapperSidebarTimerList.vue
+++ b/src/components/WrapperSidebarTimerList.vue
@@ -1,6 +1,7 @@
 <template>
   <v-list-group
     prepend-icon="alarm"
+    color="primary"
     value="true">
     <v-list-tile slot="activator">
       <v-list-tile-title>
@@ -11,6 +12,17 @@
       v-for="timer in getTimers"
       :key="timer.uid"
       :timer="timer" />
+    <v-list-tile to='/timer'>
+     <v-list-tile-action />
+      <v-list-tile-title>
+        Add a New Timer
+      </v-list-tile-title>
+       <v-list-tile-action>
+        <v-icon small color="primary">
+          add
+        </v-icon>
+      </v-list-tile-action>
+    </v-list-tile>
   </v-list-group>
 </template>
 

--- a/src/components/WrapperSidebarTimerListItem.vue
+++ b/src/components/WrapperSidebarTimerListItem.vue
@@ -41,6 +41,9 @@ export default {
     formattedDuration() {
       return countdown => timeFormat(countdown);
     },
+    isActive() {
+      return this.getActiveTimer === this.timer.uid;
+    }
   },
   watch: {
     timer(t) {
@@ -56,7 +59,7 @@ export default {
       'setActiveTimer', 'resetTimer'
     ]),
     activateTimer() {
-      if (this.$router.currentRoute.name === 'timer' && this.getActiveTimer !== this.timer.uid) {
+      if (this.$router.currentRoute.name === 'timer' && !this.isActive) {
         this.setActiveTimer(this.timer.uid);
       } else if (this.$router.currentRoute.name === 'timer') {
         this.resetTimer();


### PR DESCRIPTION
This moves the 'add a new timer' link to the collapsible list of timers. It also resizes and restructures some icons to look a little more pleasing.