### PR TITLE
Notification updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6723,6 +6723,11 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "howler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.1.1.tgz",
+      "integrity": "sha512-9nwyDCGxhAGMmNXDfMLv0M/uS/WUg2//jG6t96D8DqbbsVZgXQzsP/ZMItbWO/Fqg7Gg69kOv3xVSDzJdd7aqA=="
+    },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "chart.js": "^2.7.3",
     "dexie": "^2.0.4",
+    "howler": "^2.1.1",
     "lodash": "^4.17.11",
     "moment": "2.21.0",
     "promise-polyfill": "8.1.0",

--- a/src/layouts/Wrapper.vue
+++ b/src/layouts/Wrapper.vue
@@ -29,8 +29,8 @@
 
 <script>
 import moment from 'moment';
-import { mapActions, mapGetters } from 'vuex';
 import Push from 'push.js';
+import { mapActions, mapGetters } from 'vuex';
 import WrapperSidebar from '../components/WrapperSidebar';
 import { TIMER_STATUSES } from '../utils/timer';
 
@@ -62,7 +62,7 @@ export default {
         document.title = 'DownTimer.io';
 
         Push.create("Time's Up!", {
-          body: `Timer '${this.timer.title}' has expired.`,
+          body: `Your timer '${this.timer.title}' has finished.`,
           timeout: 4000,
         });
 

--- a/src/layouts/Wrapper.vue
+++ b/src/layouts/Wrapper.vue
@@ -89,6 +89,13 @@ export default {
     this.initTimer();
     this.timer = this.getTimerById(this.getActiveTimer);
 
+    if (Push.Permission.get() === Push.Permission.DEFAULT) {
+      Push.create('DownTimer Notification', {
+        body: 'This is where DownTimer notifications will appear.',
+        timeout: 4000
+      });
+    }
+
     window.addEventListener('beforeunload', this.exitHandler);
     document.addEventListener('swUpdated', this.showRefreshUI);
   },

--- a/src/layouts/Wrapper.vue
+++ b/src/layouts/Wrapper.vue
@@ -29,7 +29,6 @@
 
 <script>
 import moment from 'moment';
-import Push from 'push.js';
 import { mapActions, mapGetters } from 'vuex';
 import WrapperSidebar from '../components/WrapperSidebar';
 import { TIMER_STATUSES } from '../utils/timer';
@@ -61,7 +60,7 @@ export default {
       if (status === TIMER_STATUSES.EXPIRED) {
         document.title = 'DownTimer.io';
 
-        Push.create("Time's Up!", {
+        this.$native_notification.notify("Time's Up!", {
           body: `Your timer '${this.timer.title}' has finished.`,
           timeout: 4000,
         });
@@ -89,8 +88,8 @@ export default {
     this.initTimer();
     this.timer = this.getTimerById(this.getActiveTimer);
 
-    if (Push.Permission.get() === Push.Permission.DEFAULT) {
-      Push.create('DownTimer Notification', {
+    if (this.$native_notification.hasDefaultPermission()) {
+      this.$native_notification.notify('DownTimer Notification', {
         body: 'This is where DownTimer notifications will appear.',
         timeout: 4000
       });

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import './plugins/vuetify';
 import Wrapper from './layouts/Wrapper.vue';
 import store from './store';
 import AlertChime from './plugins/alert_chime.js';
+import NativeNotification from './plugins/native_notification';
 
 import router from './router';
 import './registerServiceWorker';
@@ -12,6 +13,7 @@ import './registerServiceWorker';
 Vue.config.productionTip = false;
 
 Vue.use(AlertChime);
+Vue.use(NativeNotification);
 
 new Vue({
   store,

--- a/src/plugins/alert_chime.js
+++ b/src/plugins/alert_chime.js
@@ -1,3 +1,4 @@
+import { Howl } from 'howler';
 import arpeggio from '@/assets/sounds/arpeggio.mp3';
 import coins from '@/assets/sounds/coins.mp3';
 import definite from '@/assets/sounds/definite.mp3';
@@ -9,21 +10,8 @@ const CHIMES = {
 };
 
 const play = (chime) => {
-  return new Promise((resolve, reject) => {
-    if ('Audio' in window) {
-      resolve();
-    } else {
-      reject(Error('Audio API not available'));
-    }
-  })
-    .then(() => {
-      const audio = new Audio(CHIMES[chime]);
-      return audio.play();
-    })
-    .catch((err) => {
-      /* eslint-disable no-console */
-      console.log(err);
-    });
+  const alertChime = new Howl({src: [CHIMES[chime]]});
+  alertChime.play();
 };
 
 const AlertChime = {

--- a/src/plugins/native_notification.js
+++ b/src/plugins/native_notification.js
@@ -1,0 +1,15 @@
+import Push from 'push.js';
+
+const notify = (title, opts) => Push.create(title, opts);
+
+const hasDefaultPermission = () => Push.Permission.get() === Push.Permission.DEFAULT;
+
+const NativeNotification = {
+  install: (Vue) => {
+    Vue.native_notification = { notify, hasDefaultPermission };
+    Vue.prototype.$native_notification = { notify, hasDefaultPermission };
+  }
+};
+
+
+export default NativeNotification;

--- a/tests/unit/__mocks__/plugins.js
+++ b/tests/unit/__mocks__/plugins.js
@@ -12,16 +12,12 @@ export const AlertChime = {
 export const NativeNotification = {
   install: (Vue) => {
     Vue.native_notification = {
-      play: () => {},
       notify: () => {},
-      hasPermission: () => {},
-      requestPermission: () => {}
+      hasDefaultPermission: () => false
     };
     Vue.prototype.$native_notification = {
-      play: () => {},
       notify: () => {},
-      hasPermission: () => {},
-      requestPermission: () => {}
+      hasDefaultPermission: () => false
     };
   }
 };

--- a/tests/unit/components/TimerControls.spec.js
+++ b/tests/unit/components/TimerControls.spec.js
@@ -5,7 +5,6 @@ import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
 import TimerControls from '@/components/TimerControls';
 import { state, actions, getters } from '../__mocks__/store';
-import { AlertChime, NativeNotification } from '../__mocks__/plugins';
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -13,8 +12,6 @@ chai.use(sinonChai);
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(Vuetify);
-localVue.use(AlertChime);
-localVue.use(NativeNotification);
 
 describe('Timer.vue', () => {
   let store;

--- a/tests/unit/layouts/Wrapper.spec.js
+++ b/tests/unit/layouts/Wrapper.spec.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import Vuetify from 'vuetify';
 import Router from 'vue-router';
 import { state, actions, getters } from '../__mocks__/store';
+import { AlertChime, NativeNotification } from '../__mocks__/plugins';
 
 import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
@@ -16,6 +17,8 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(Vuetify);
 localVue.use(Router);
+localVue.use(AlertChime);
+localVue.use(NativeNotification);
 
 describe('Wrapper.vue', () => {
   let store;

--- a/tests/unit/views/Settings.spec.js
+++ b/tests/unit/views/Settings.spec.js
@@ -4,7 +4,7 @@ import Vuetify from 'vuetify';
 import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
 import Settings from '@/views/Settings';
-import { AlertChime, NativeNotification } from '../__mocks__/plugins';
+import { AlertChime } from '../__mocks__/plugins';
 import { state, actions, getters } from '../__mocks__/store';
 
 const { expect } = chai;
@@ -14,7 +14,6 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(Vuetify);
 localVue.use(AlertChime);
-localVue.use(NativeNotification);
 
 describe('Settings.vue', () => {
   let store;

--- a/tests/unit/views/Timer.spec.js
+++ b/tests/unit/views/Timer.spec.js
@@ -7,7 +7,6 @@ import Timer from '@/views/Timer';
 import TimerFace from '@/components/TimerFace';
 import TimerControls from '@/components/TimerControls';
 import { state, actions, getters } from '../__mocks__/store';
-import { AlertChime, NativeNotification } from '../__mocks__/plugins';
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -15,8 +14,6 @@ chai.use(sinonChai);
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(Vuetify);
-localVue.use(AlertChime);
-localVue.use(NativeNotification);
 
 describe('Timer.vue', () => {
   let store;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug fix
- [ ] New feature

**What is the current behavior?**
Notifications required permission after first notification was to appear. Alert chimes didn't fire on inactive tabs without prior interaction.

**What is the new behavior?**
Notifications are requested on invocation (via push.js). Alert chimes run on inactive tabs by faking interaction (via howler.js)

**Other information**
Addresses #18  and #19 