### PR TITLE
Incorrect progress bar

### DIFF
--- a/src/store/modules/timers/actions.js
+++ b/src/store/modules/timers/actions.js
@@ -37,6 +37,7 @@ export const actions = {
 
       if (timers.length) {
         store.commit(SET_ACTIVE_TIMER, timers[0].uid);
+        store.commit(UPDATE_TIMER_VALUE, timers[0].duration);
       }
     }
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug fix
- [ ] New feature

**What is the current behavior?**
When loading saved timers, the duration would not get set properly. This resulted in incorrect progress bars on initial load.

For example, the default duration is 20 minutes. If a single timer were saved with a duration of 30 minutes, the next page load would show a progress bar at 33.33% complete (30 duration, 20 remaining = 10/30).

**What is the new behavior?**
Current time is set to match new duration.

**Other information**
